### PR TITLE
Force normal mode on lowmem devices

### DIFF
--- a/InstallNET.sh
+++ b/InstallNET.sh
@@ -538,7 +538,7 @@ if [[ "$loaderMode" == "0" ]]; then
   [[ "$setInterfaceName" == "1" ]] && Add_OPTION="net.ifnames=0 biosdevname=0" || Add_OPTION=""
   [[ "$setIPv6" == "1" ]] && Add_OPTION="$Add_OPTION ipv6.disable=1"
   
-  lowMem || Add_OPTION="$Add_OPTION lowmem/low=1"
+  lowMem || Add_OPTION="$Add_OPTION lowmem=+0"
 
   if [[ "$linux_relese" == 'debian' ]] || [[ "$linux_relese" == 'ubuntu' ]]; then
     BOOT_OPTION="auto=true $Add_OPTION hostname=$linux_relese domain= -- quiet"


### PR DESCRIPTION
I've tested on a 350 MB memory device. The installation was succeeded.
Fixes https://github.com/MoeClub/Note/issues/6#issuecomment-946011372

https://salsa.debian.org/installer-team/lowmem/-/blob/bbb4ed4c4da20d585cf30ceba9f0987173d3ac70/debian-installer-startup.d/S15lowmem#L103