### PR TITLE
pass net.ifnames=0 to debian/ubuntu installed grub

### DIFF
--- a/InstallNET.sh
+++ b/InstallNET.sh
@@ -100,7 +100,7 @@ while [[ $# -ge 1 ]]; do
       ipDNS="$1"
       shift
       ;;
-    --dev-net)
+    --dev-net|--set-ifname)
       shift
       setInterfaceName='1'
       ;;
@@ -148,7 +148,7 @@ while [[ $# -ge 1 ]]; do
       ;;
     *)
       if [[ "$1" != 'error' ]]; then echo -ne "\nInvaild option: '$1'\n\n"; fi
-      echo -ne " Usage:\n\tbash $(basename $0)\t-d/--debian [\033[33m\033[04mdists-name\033[0m]\n\t\t\t\t-u/--ubuntu [\033[04mdists-name\033[0m]\n\t\t\t\t-c/--centos [\033[04mdists-name\033[0m]\n\t\t\t\t-v/--ver [32/i386|64/\033[33m\033[04mamd64\033[0m] [\033[33m\033[04mdists-verison\033[0m]\n\t\t\t\t--ip-addr/--ip-gate/--ip-mask\n\t\t\t\t-apt/-yum/--mirror\n\t\t\t\t-dd/--image\n\t\t\t\t-p [linux password]\n\t\t\t\t-port [linux ssh port]\n"
+      echo -ne " Usage:\n\tbash $(basename $0)\t-d/--debian [\033[33m\033[04mdists-name\033[0m]\n\t\t\t\t-u/--ubuntu [\033[04mdists-name\033[0m]\n\t\t\t\t-c/--centos [\033[04mdists-name\033[0m]\n\t\t\t\t-v/--ver [32/i386|64/\033[33m\033[04mamd64\033[0m] [\033[33m\033[04mdists-verison\033[0m]\n\t\t\t\t--ip-addr/--ip-gate/--ip-mask\n\t\t\t\t-apt/-yum/--mirror\n\t\t\t\t-dd/--image\n\t\t\t\t-p [linux password]\n\t\t\t\t-port [linux ssh port]\n\t\t\t\t--set-ifname\n"
       exit 1;
       ;;
     esac

--- a/InstallNET.sh
+++ b/InstallNET.sh
@@ -549,7 +549,6 @@ if [[ "$loaderMode" == "0" ]]; then
   LinuxIMG="$(grep 'initrd.*/' /tmp/grub.new |awk '{print $1}' |tail -n 1)";
   [ -z "$LinuxIMG" ] && sed -i "/$LinuxKernel.*\//a\\\tinitrd\ \/" /tmp/grub.new && LinuxIMG='initrd';
 
-  [[ "$setInterfaceName" == "1" ]] && Add_OPTION="net.ifnames=0 biosdevname=0" || Add_OPTION=""
   [[ "$setIPv6" == "1" ]] && Add_OPTION="$Add_OPTION ipv6.disable=1"
   
   lowMem || Add_OPTION="$Add_OPTION lowmem=+2"
@@ -559,8 +558,11 @@ if [[ "$loaderMode" == "0" ]]; then
   elif [[ "$linux_relese" == 'centos' ]]; then
     BOOT_OPTION="ks=file://ks.cfg $Add_OPTION ksdevice=$interfaceSelect"
   fi
-  
-  [ -n "$setConsole" ] && BOOT_OPTION="$BOOT_OPTION --- console=$setConsole"
+ 
+  #options to pass to installed system
+  BOOT_OPTION="$BOOT_OPTION ---"
+  [ -n "$setConsole" ] && BOOT_OPTION="$BOOT_OPTION console=$setConsole"
+  [[ "$setInterfaceName" == "1" ]] && BOOT_OPTION="$BOOT_OPTION net.ifnames=0 biosdevname=0" || BOOT_OPTION=""
 
   [[ "$Type" == 'InBoot' ]] && {
     sed -i "/$LinuxKernel.*\//c\\\t$LinuxKernel\\t\/boot\/vmlinuz $BOOT_OPTION" /tmp/grub.new;


### PR DESCRIPTION
the `--dev-net` option can make interface names to be eth0 instead of ensxxx during install process.
but the `net.ifnames=0` boot option will be missing in installed system, which may cause network config fail.

fix this by add those option after thee hyphen, eg "---".