### PR TITLE
修复制作loader的BUG

### DIFF
--- a/InstallNET.sh
+++ b/InstallNET.sh
@@ -783,22 +783,23 @@ EOF
 fi
 
 find . | cpio -H newc --create --verbose | gzip -9 > /tmp/initrd.img;
-cp -f /tmp/initrd.img /boot/initrd.img || sudo cp -f /tmp/initrd.img /boot/initrd.img
-cp -f /tmp/vmlinuz /boot/vmlinuz || sudo cp -f /tmp/vmlinuz /boot/vmlinuz
-
-chown root:root $GRUBDIR/$GRUBFILE
-chmod 444 $GRUBDIR/$GRUBFILE
 
 if [[ "$loaderMode" == "0" ]]; then
+  cp -f /tmp/initrd.img /boot/initrd.img || sudo cp -f /tmp/initrd.img /boot/initrd.img
+  cp -f /tmp/vmlinuz /boot/vmlinuz || sudo cp -f /tmp/vmlinuz /boot/vmlinuz
+  
+  chown root:root $GRUBDIR/$GRUBFILE
+  chmod 444 $GRUBDIR/$GRUBFILE
+  
   sleep 3 && reboot || sudo reboot >/dev/null 2>&1
 else
   rm -rf "$HOME/loader"
   mkdir -p "$HOME/loader"
-  cp -rf "/boot/initrd.img" "$HOME/loader/initrd.img"
-  cp -rf "/boot/vmlinuz" "$HOME/loader/vmlinuz"
-  [[ -f "/boot/initrd.img" ]] && rm -rf "/boot/initrd.img"
-  [[ -f "/boot/vmlinuz" ]] && rm -rf "/boot/vmlinuz"
+  cp -rf "/tmp/initrd.img" "$HOME/loader/initrd.img"
+  cp -rf "/tmp/vmlinuz" "$HOME/loader/vmlinuz"
+
+  [[ -f "/tmp/initrd.img" ]] && rm -rf "/tmp/initrd.img"
+  [[ -f "/tmp/vmlinuz" ]] && rm -rf "/tmp/vmlinuz"
   echo && ls -AR1 "$HOME/loader"
 fi
-
 


### PR DESCRIPTION
修改GRUB文件权限和文件复制（initrd.img vmlinuz）没有在 loaderMode判断下引发以下两个问题： 1.默认会替换（initrd.img vmlinuz），如果机器的内核同名，重启将会引起问题。

2.制作loader时由于 $GRUBDIR $GRUBFILE 这两个变量为空，导致执行成
chown root:root /
chmod 444 /
会让机器莫名其妙的炸了，感谢huggy大佬出手相救。